### PR TITLE
[npm] Adds .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 .git/
+.cache/
 test.*
-dist/*
 index.html
 .travis.yml
 .eslintrc.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.git/
+test.*
+dist/*
+index.html
+.travis.yml
+.eslintrc.js


### PR DESCRIPTION
Reduces package size from 120KB to 6kB

```
$ npm publish --dry-run
npm notice 
npm notice 📦  @razorpay/lytics@1.0.0
npm notice === Tarball Contents === 
npm notice 1.2kB package.json       
npm notice 1.1kB LICENSE            
npm notice 909B  lytics.js          
npm notice 5.0kB README.md          
npm notice 1.6kB utils/attributes.js
npm notice 2.8kB utils/callbacks.js 
npm notice 1.8kB utils/listeners.js 
npm notice 2.0kB utils/trackers.js  
npm notice === Tarball Details === 
npm notice name:          @razorpay/lytics                        
npm notice version:       1.0.0                                   
npm notice package size:  6.0 kB                                  
npm notice unpacked size: 16.5 kB                                 
npm notice shasum:        585023b4664337c67c57105b55383b0b4dacb78c
npm notice integrity:     sha512-WWbhh7X4GEi7y[...]W1wFK+w4jvYww==
npm notice total files:   8                                       
npm notice 
+ @razorpay/lytics@1.0.0
```

v/s 1.0 published:

```
du 
20K	./utils
8K	./dist
12K	./.git/refs/remotes/origin
16K	./.git/refs/remotes
20K	./.git/refs
12K	./.git/logs/refs/remotes/origin
16K	./.git/logs/refs/remotes
20K	./.git/logs/refs
24K	./.git/logs
48K	./.git
120K	.
```